### PR TITLE
Reconfigure widget on click

### DIFF
--- a/app/src/main/java/com/example/aikataulu/TimetableRemoteViewsService.kt
+++ b/app/src/main/java/com/example/aikataulu/TimetableRemoteViewsService.kt
@@ -1,5 +1,6 @@
 package com.example.aikataulu
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
@@ -10,6 +11,7 @@ import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import com.example.aikataulu.models.Timetable
 import com.example.aikataulu.providers.TimetableDataProvider
+import com.example.aikataulu.ui.ConfigurationActivity
 
 // https://android.googlesource.com/platform/development/+/master/samples/WeatherListWidget/src/com/example/android/weatherlistwidget/WeatherWidgetService.java
 class TimetableRemoteViewsService : RemoteViewsService() {

--- a/app/src/main/java/com/example/aikataulu/TimetableWidgetProvider.kt
+++ b/app/src/main/java/com/example/aikataulu/TimetableWidgetProvider.kt
@@ -45,29 +45,6 @@ class TimetableWidgetProvider : AppWidgetProvider() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context!!.startForegroundService(Intent(context, TimetableService::class.java))
         } else throw Exception("TIMETABLE: SDK Level too low. Cannot start foreground service.")
-        // Perform this loop procedure for each App Widget that belongs to this provider
-        getExistingWidgetIds(context).forEach { widgetId ->
-            Log.i(TAG, "Attaching click handler to widget id $widgetId")
-            AppWidgetManager.getInstance(context)
-                .updateAppWidget(widgetId, RemoteViews(context.packageName, R.layout.widget)
-                    .apply {
-                        setOnClickPendingIntent(R.id.widgetContainer,
-                            Intent(context, ConfigurationActivity::class.java)
-                                .let { intent ->
-                                    intent.putExtra(
-                                        AppWidgetManager.EXTRA_APPWIDGET_ID,
-                                        widgetId
-                                    )
-                                    intent.action = "configure_widget-$widgetId"
-                                    PendingIntent.getActivity(
-                                        context,
-                                        0,
-                                        intent,
-                                        PendingIntent.FLAG_UPDATE_CURRENT
-                                    )
-                                })
-                    })
-        }
         super.onEnabled(context)
     }
 
@@ -90,6 +67,22 @@ class TimetableWidgetProvider : AppWidgetProvider() {
                                     putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetId)
                                 }
                             )
+                            setOnClickPendingIntent(R.id.widgetContainer,
+                                Intent(context, ConfigurationActivity::class.java)
+                                    .let { intent ->
+                                        intent.putExtra(
+                                            AppWidgetManager.EXTRA_APPWIDGET_ID,
+                                            widgetId
+                                        )
+                                        intent.action = "configure_widget-$widgetId"
+                                        intent.type = "configure_widget-$widgetId"
+                                        PendingIntent.getActivity(
+                                            context,
+                                            widgetId,
+                                            intent,
+                                            PendingIntent.FLAG_UPDATE_CURRENT
+                                        )
+                                    })
                         })
 
                     notifyAppWidgetViewDataChanged(widgetId, R.id.widget_content_target)

--- a/app/src/main/java/com/example/aikataulu/database/contracts/Stop.kt
+++ b/app/src/main/java/com/example/aikataulu/database/contracts/Stop.kt
@@ -1,6 +1,9 @@
 package com.example.aikataulu.database.contracts
 
+import android.database.Cursor
 import android.provider.BaseColumns
+import com.example.aikataulu.TimetableConfiguration
+import com.example.aikataulu.models.Stop
 
 object StopContract {
     const val SQL_CREATE_ENTRIES =
@@ -20,6 +23,16 @@ object StopContract {
                 COLUMN_NAME_HRTID,
                 COLUMN_NAME_STOPNAME
             )
+        }
+        fun cursorToPoco(cursor: Cursor?): Stop? {
+            return if (cursor != null) {
+                val entry = StopEntry
+                val hrtId =
+                    cursor.getString(cursor.getColumnIndex(entry.COLUMN_NAME_HRTID))
+                val name =
+                    cursor.getString(cursor.getColumnIndex(entry.COLUMN_NAME_STOPNAME))
+                Stop(name, hrtId)
+            } else null
         }
     }
 }

--- a/app/src/main/java/com/example/aikataulu/providers/StopProvider.kt
+++ b/app/src/main/java/com/example/aikataulu/providers/StopProvider.kt
@@ -2,22 +2,35 @@ package com.example.aikataulu
 
 import android.content.ContentProvider
 import android.content.ContentValues
+import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE
 import android.net.Uri
 import android.util.Log
 import com.example.aikataulu.database.TimetableDbHelper
-import com.example.aikataulu.database.contracts.ConfigurationContract
 import com.example.aikataulu.database.contracts.StopContract
+import com.example.aikataulu.models.Stop
 
 class StopProvider : ContentProvider() {
-    private val entry = StopContract.StopEntry
     private lateinit var dbHelper: TimetableDbHelper
 
     companion object {
+        private val entry = StopContract.StopEntry
         const val TAG = "TIMETABLE.ConfigurationProvider"
         val STOP_URI: Uri =
             Uri.parse("content://com.example.android.aikataulu.stop_provider")
+
+        fun getStopByIdOrNull(hrtId: String, context: Context): Stop? {
+            val cursor = context.contentResolver.query(
+                STOP_URI,
+                null,
+                "${entry.COLUMN_NAME_HRTID} = ?",
+                arrayOf(hrtId),
+                null,
+                null
+            )
+            return if (cursor?.moveToFirst() == true) entry.cursorToPoco(cursor) else null
+        }
     }
 
     override fun onCreate(): Boolean {

--- a/app/src/main/res/layout/configuration_activity.xml
+++ b/app/src/main/res/layout/configuration_activity.xml
@@ -17,7 +17,7 @@
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginTop="24dp"
+            android:layout_marginTop="16dp"
             android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -38,7 +38,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:background="@drawable/button_bg"
+                android:background="@android:drawable/btn_default"
                 android:text="@string/label_button_save" />
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Open configuration activity on widget click
- Load configuration ViewModel based on WidgetId when opening config screen
- Use user-friendly format for Stop config item value